### PR TITLE
Add AI agent docs and PHP dev skills

### DIFF
--- a/.ai/skills/development/SKILL.md
+++ b/.ai/skills/development/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: schedulepress-php-development
+name: schedulepress-development
 description: Add or modify SchedulePress backend PHP code following project conventions. Use when creating new classes, methods, hooks, or modifying existing backend code. **MUST be invoked before writing any PHP unit tests.**
 ---
 
@@ -24,9 +24,7 @@ Follow SchedulePress project conventions when adding or modifying backend PHP co
 2. **Naming conventions**: See [code-entities.md](code-entities.md) for naming methods, variables, and parameters
 3. **Coding style**: See [coding-conventions.md](coding-conventions.md) for general coding standards and best practices
 4. **Working with hooks**: See [hooks.md](hooks.md) for hook callback conventions and documentation
-5. **Dependency injection**: See [dependency-injection.md](dependency-injection.md) for component initialization patterns
-6. **Data integrity**: See [data-integrity.md](data-integrity.md) for ensuring data integrity when performing CRUD operations
-7. **Writing tests**: See [unit-tests.md](unit-tests.md) for unit testing conventions
+5. **Writing tests**: See [unit-tests.md](unit-tests.md) for unit testing conventions
 
 ## Key Principles
 

--- a/.ai/skills/development/SKILL.md
+++ b/.ai/skills/development/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: schedulepress-php-development
+description: Add or modify SchedulePress backend PHP code following project conventions. Use when creating new classes, methods, hooks, or modifying existing backend code. **MUST be invoked before writing any PHP unit tests.**
+---
+
+# SchedulePress Backend Development
+
+This skill provides guidance for developing SchedulePress backend PHP code according to project standards and conventions.
+
+## When to Use This Skill
+
+**ALWAYS invoke this skill before:**
+
+- Writing new PHP unit tests (`*Test.php` files)
+- Creating new PHP classes
+- Modifying existing backend PHP code
+- Adding hooks or filters
+
+## Instructions
+
+Follow SchedulePress project conventions when adding or modifying backend PHP code:
+
+1. **Creating new code structures**: See [file-entities.md](file-entities.md) for conventions on creating classes and organizing files (but for new unit test files see [unit-tests.md](unit-tests.md)).
+2. **Naming conventions**: See [code-entities.md](code-entities.md) for naming methods, variables, and parameters
+3. **Coding style**: See [coding-conventions.md](coding-conventions.md) for general coding standards and best practices
+4. **Working with hooks**: See [hooks.md](hooks.md) for hook callback conventions and documentation
+5. **Dependency injection**: See [dependency-injection.md](dependency-injection.md) for component initialization patterns
+6. **Data integrity**: See [data-integrity.md](data-integrity.md) for ensuring data integrity when performing CRUD operations
+7. **Writing tests**: See [unit-tests.md](unit-tests.md) for unit testing conventions
+
+## Key Principles
+
+- Always follow WordPress Coding Standards
+- Use class methods instead of standalone functions
+- Place new PHP classes in `includes/` subdirectories under the appropriate namespace
+- Use PSR-4 autoloading with `WPSP\` as the root namespace mapped to `includes/`
+- Write comprehensive unit tests for new functionality in `tests/unit/`
+- Run linting and tests before committing changes
+
+## Version Information
+
+To determine the current SchedulePress version number for `@since` annotations:
+
+- Read the `Version` header in `wp-scheduled-posts.php`
+- Example: If the header shows `Version: 5.2.17`, use `@since 5.2.17`

--- a/.ai/skills/development/code-entities.md
+++ b/.ai/skills/development/code-entities.md
@@ -1,0 +1,186 @@
+# Creating Code Entities (Methods, Variables, Parameters)
+
+## Table of Contents
+
+- [Naming Conventions](#naming-conventions)
+- [Method Visibility](#method-visibility)
+- [Static Methods](#static-methods)
+- [Docblock Requirements](#docblock-requirements)
+    - [Public, Protected Methods, and Hooks](#public-protected-methods-and-hooks)
+    - [Private Methods and Internal Callbacks](#private-methods-and-internal-callbacks)
+    - [@internal Annotation Placement](#internal-annotation-placement)
+- [Hook Docblocks](#hook-docblocks)
+
+## Naming Conventions
+
+Use snake_case for methods, variables, and hooks (not camelCase or PascalCase).
+
+**Examples:**
+
+```php
+// Correct
+public function calculate_order_total() { }
+private $order_items;
+```
+
+## Method Visibility
+
+New class methods should be `private` by default.
+
+**Use `protected`** only if it's clear the method will be used in derived classes.
+
+**Use `public`** only if the method will be called from outside the class.
+
+**Examples:**
+
+```php
+class AutoScheduler {
+    // Default: private for internal helpers
+    private function validate_slot( array $slot ) { }
+
+    // Protected: for use in child classes
+    protected function get_schedule_interval( string $post_type ) { }
+
+    // Public: external API
+    public function schedule_post( int $post_id ) { }
+}
+```
+
+## Static Methods
+
+Pure methods (output depends only on inputs, no external dependencies) must be `static`.
+
+**Examples of pure methods (should be static):**
+
+```php
+// Mathematical calculations
+public static function calculate_percentage( float $amount, float $percent ) {
+    return $amount * ( $percent / 100 );
+}
+
+// String manipulations
+public static function sanitize_social_message( string $message ) {
+    return trim( wp_strip_all_tags( $message ) );
+}
+
+// Data transformations
+public static function normalize_schedule_data( array $data ) {
+    return array_map( 'trim', $data );
+}
+```
+
+**Examples of non-pure methods (should NOT be static):**
+
+```php
+// Depends on database
+public function get_scheduled_posts( string $post_type ) { }
+
+// Depends on system time
+public function is_slot_available( int $timestamp ) { }
+
+// Uses object state
+public function get_next_slot_with_buffer( int $timestamp ) {
+    return $timestamp + $this->buffer_seconds;
+}
+```
+
+**Exception:** Non-pure methods should not be `static` unless there's a specific architectural reason (e.g., singleton pattern, factory methods).
+
+## Docblock Requirements
+
+Add concise docblocks to all hooks and methods. One line is ideal.
+
+### Public, Protected Methods, and Hooks
+
+Must include a `@since` annotation with the current SchedulePress version number.
+
+The `@since` annotation must be:
+
+- The last line in the docblock
+- Preceded by a blank comment line
+- Use the version from the `Version` header in `wp-scheduled-posts.php`
+  (e.g., if the header shows `Version: 5.2.17`, use `@since 5.2.17`)
+
+**Good - Concise:**
+
+```php
+/**
+ * Schedule a post and update its status.
+ *
+ * @param int $post_id The post ID.
+ * @return bool True if successful.
+ *
+ * @since 5.2.17
+ */
+public function schedule_post( int $post_id ) { }
+
+/**
+ * Fires after a post is auto-scheduled.
+ *
+ * @param int $post_id The post ID.
+ *
+ * @since 5.2.17
+ */
+do_action( 'wpsp_post_scheduled', $post_id );
+```
+
+**Avoid - Over-explained:**
+
+```php
+/**
+ * This method processes the order by validating the order data,
+ * checking inventory levels, processing payment, and then updating
+ * the order status to reflect the successful processing.
+ *
+ * @param int $order_id The unique identifier for the order that needs to be processed.
+ * @return bool Returns true if the order was processed successfully, false otherwise.
+ *
+ * @since 9.5.0
+ */
+```
+
+For hooks, aim for a single descriptive line whenever possible.
+
+### Private Methods and Internal Callbacks
+
+Do NOT require a `@since` annotation if they are:
+
+- Private methods
+- Internal callbacks (marked with `@internal`)
+
+**Example:**
+
+```php
+/**
+ * Internal helper to validate order items.
+ *
+ * @param array $items The items to validate.
+ * @return bool
+ */
+private function validate_items( array $items ) { }
+```
+
+### @internal Annotation Placement
+
+When an `@internal` annotation is added, it must be:
+
+- Placed after the method description
+- Placed before the arguments list
+- Have a blank comment line before and after
+
+**Example:**
+
+```php
+/**
+ * Handle the wpsp_init hook.
+ *
+ * @internal
+ *
+ * @param array $args Hook arguments.
+ */
+public function handle_wpsp_init( array $args ) { }
+```
+
+## Hook Docblocks
+
+For information about documenting hooks (including adding docblocks to existing hooks), see [hooks.md](hooks.md).

--- a/.ai/skills/development/coding-conventions.md
+++ b/.ai/skills/development/coding-conventions.md
@@ -1,0 +1,150 @@
+# General Coding Conventions
+
+## Table of Contents
+
+- [Code Clarity and Comments](#code-clarity-and-comments)
+- [WordPress Coding Standards](#wordpress-coding-standards)
+- [Null Coalescing Operator](#null-coalescing-operator)
+- [Ternary Operator](#ternary-operator)
+- [call_user_func_array() Usage](#call_user_func_array-usage)
+- [Linting](#linting)
+
+## Code Clarity and Comments
+
+Write self-explanatory code. Use comments sparingly - only for non-obvious insights.
+
+**Good - Code explains itself:**
+
+```php
+if ( $post->is_scheduled() && $user->can_manage_schedules() ) {
+    $post->unschedule();
+}
+```
+
+**Avoid - Over-commented:**
+
+```php
+// Check if post is scheduled
+if ( $post->is_scheduled() ) {
+    // Check if user has permission
+    if ( $user->can_manage_schedules() ) {
+        // Unschedule the post
+        $post->unschedule();
+    }
+}
+```
+
+**When to add comments:**
+
+- Unusual decisions, workarounds, or non-obvious business logic
+- Performance considerations
+
+**When NOT to add comments:**
+
+- Explaining what code does (code should be self-explanatory)
+- Restating the obvious
+
+## WordPress Coding Standards
+
+Follow [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/):
+
+- **Yoda conditions**: `'true' === $value` not `$value === 'true'`
+- **Spacing**: Spaces around operators, inside parentheses
+- **Braces**: Opening on same line, closing on new line
+- **Naming**: snake_case for functions and variables
+
+## Null Coalescing Operator
+
+Use `??` instead of `isset` checks for array access.
+
+**Good:**
+
+```php
+if ( 34 === ( $foo['bar'] ?? null ) ) {
+    // ...
+}
+
+$value = $options['setting'] ?? 'default';
+```
+
+**Avoid:**
+
+```php
+if ( isset( $foo['bar'] ) && 34 === $foo['bar'] ) {
+    // ...
+}
+
+if ( isset( $options['setting'] ) ) {
+    $value = $options['setting'];
+} else {
+    $value = 'default';
+}
+```
+
+## Ternary Operator
+
+Prefer the ternary operator over if-else statements for simple conditional returns or assignments, except for very complex cases.
+
+**Good:**
+
+```php
+return $condition ? $true_value : $false_value;
+
+$result = $is_enabled ? 'enabled' : 'disabled';
+
+$interval = $is_custom ? $settings->get_custom_interval() : $settings->get_default_interval();
+```
+
+**Avoid:**
+
+```php
+if ( $condition ) {
+    return $true_value;
+}
+return $false_value;
+
+if ( $is_enabled ) {
+    $result = 'enabled';
+} else {
+    $result = 'disabled';
+}
+```
+
+**Exception:** Use traditional if-else for complex conditions or when multiple statements are needed in each branch.
+
+```php
+// OK to use if-else when complex logic is involved
+if ( $post->needs_scheduling() && ! $post->has_valid_publish_date() ) {
+    $this->logger->log( 'Invalid publish date for post ' . $post->ID );
+    $this->notify_author( $post );
+    return false;
+} else {
+    return true;
+}
+```
+
+## call_user_func_array() Usage
+
+When using `call_user_func_array()`, always use **positional arguments** (numerically indexed array) instead of named/associative arrays for the arguments parameter.
+
+The function uses array values in order and ignores keys, so named keys are misleading.
+
+**Correct:**
+
+```php
+call_user_func_array( array( $obj, 'method' ), array( $code ) );
+call_user_func_array( array( $obj, 'process' ), array( $id, $status, $data ) );
+```
+
+**Wrong:**
+
+```php
+call_user_func_array( array( $obj, 'method' ), array( 'country_code' => $code ) );
+call_user_func_array( array( $obj, 'process' ), array( 'order_id' => $id, 'status' => $status ) );
+```
+
+## Linting
+
+Only fix linting errors for code that has been added or modified in the branch you are working on.
+
+Do not fix linting errors in unrelated code unless specifically asked to do so.

--- a/.ai/skills/development/file-entities.md
+++ b/.ai/skills/development/file-entities.md
@@ -1,0 +1,73 @@
+# Creating File-Based Code Entities
+
+## Fundamental Rule: No Standalone Functions
+
+**NEVER add new standalone functions** - they're difficult to mock in unit tests. Always use class methods.
+
+Exception: `includes/functions.php` contains plugin-wide global helpers that are loaded early. Only add to this file when a truly global, stateless utility is needed and it cannot belong to a class.
+
+## Adding New Classes
+
+### Default Location: `includes/`
+
+New PHP classes go in `includes/` under the appropriate subdirectory matching their namespace:
+
+| Subdirectory | Namespace | Purpose |
+| ------------ | --------- | ------- |
+| `includes/Admin/` | `WPSP\Admin\` | Admin UI, settings, metaboxes, calendar |
+| `includes/API/` | `WPSP\API\` | REST API route handlers |
+| `includes/Social/` | `WPSP\Social\` | Social media platform integrations |
+| `includes/Helpers/` | `WPSP\Helpers\` | Reusable utility classes |
+| `includes/Traits/` | `WPSP\Traits\` | Reusable PHP traits |
+
+**Examples:**
+
+- A new social platform handler → `includes/Social/Instagram.php` with namespace `WPSP\Social`
+- A REST route for bulk scheduling → `includes/API/BulkSchedule.php` with namespace `WPSP\API`
+- A utility for calculating publish times → `includes/Helpers/TimeCalculator.php` with namespace `WPSP\Helpers`
+
+> **Note:** `src/` is reserved for the React/JavaScript frontend. Do NOT place PHP files there.
+
+## Naming Conventions
+
+### Class Names
+
+- **Must be PascalCase**
+- **Must follow [PSR-4 standard](https://www.php-fig.org/psr/psr-4/)**
+- Adjust the name given by the user if necessary
+- Root namespace for the `includes/` directory is `WPSP`
+
+**Examples:**
+
+```php
+// User says: "create a time calculator helper"
+// You create: includes/Helpers/TimeCalculator.php
+namespace WPSP\Helpers;
+
+class TimeCalculator {
+    // ...
+}
+```
+
+## Namespace and Import Conventions
+
+When referencing a namespaced class:
+
+1. Always add a `use` statement with the fully qualified class name at the beginning of the file
+2. Reference the short class name throughout the code
+
+**Good:**
+
+```php
+use WPSP\Helpers\TimeCalculator;
+
+// Later in code:
+$calculator = new TimeCalculator();
+```
+
+**Avoid:**
+
+```php
+// No use statement, using fully qualified name:
+$calculator = new \WPSP\Helpers\TimeCalculator();
+```

--- a/.ai/skills/development/hooks.md
+++ b/.ai/skills/development/hooks.md
@@ -1,0 +1,96 @@
+# Working with Hooks
+
+## Hook Callback Naming Convention
+
+Name hook callback methods: `handle_{hook_name}` with `@internal` annotation.
+
+**Examples:**
+
+```php
+/**
+ * Handle the wpsp_init hook.
+ *
+ * @internal
+ */
+public function handle_wpsp_init() {
+    // Initialize components
+}
+
+/**
+ * Handle the wpsp_before_schedule hook.
+ *
+ * @internal
+ *
+ * @param int $post_id The post being scheduled.
+ */
+public function handle_wpsp_before_schedule( $post_id ) {
+    // Pre-schedule logic
+}
+```
+
+## Hook Naming Convention
+
+SchedulePress hooks use the `wpsp_` prefix.
+
+- **Actions:** `wpsp_{event}` — e.g., `wpsp_post_scheduled`, `wpsp_auto_schedule_enabled`
+- **Filters:** `wpsp_{thing}_filter` or `wpsp_{thing}` — e.g., `wpsp_schedule_interval`, `wpsp_social_message`
+
+Avoid generic WordPress hook names without the prefix. They are hard to discover and may conflict with other plugins.
+
+## Hook Docblocks
+
+If you modify a line that fires a hook without a docblock:
+
+1. Add docblock with description and `@param` tags
+2. Use `git log -S "hook_name"` to find when it was introduced
+3. Add `@since` annotation with that version
+
+```php
+/**
+ * Fires after a post has been auto-scheduled.
+ *
+ * @param int   $post_id   The scheduled post ID.
+ * @param array $slot_data The time slot data.
+ *
+ * @since 5.1.0
+ */
+do_action( 'wpsp_post_scheduled', $post_id, $slot_data );
+```
+
+## Hook Documentation Requirements
+
+All hooks must have docblocks that include:
+
+- Description of when the hook fires
+- `@param` tags for each parameter passed to the hook
+- `@since` annotation with the version number (last line, with blank line before)
+    - For new hooks: Read the `Version` header in `wp-scheduled-posts.php`
+    - For existing hooks: Use `git log -S "hook_name"` to find when it was introduced
+
+**Action hook example:**
+
+```php
+/**
+ * Fires after a post is added to the schedule queue.
+ *
+ * @param int    $post_id  The post ID.
+ * @param string $platform The social platform slug (e.g. 'twitter', 'facebook').
+ *
+ * @since 5.2.0
+ */
+do_action( 'wpsp_social_post_queued', $post_id, $platform );
+```
+
+**Filter hook example:**
+
+```php
+/**
+ * Filters the social media message before it is sent.
+ *
+ * @param string $message The generated message text.
+ * @param int    $post_id The post ID.
+ *
+ * @since 5.2.0
+ */
+$message = apply_filters( 'wpsp_social_message', $message, $post_id );
+```

--- a/.ai/skills/development/unit-tests.md
+++ b/.ai/skills/development/unit-tests.md
@@ -1,0 +1,283 @@
+# Unit Testing Conventions
+
+## Table of Contents
+
+- [Complete Test File Template](#complete-test-file-template)
+- [Test File Naming and Location](#test-file-naming-and-location)
+- [System Under Test Variable](#system-under-test-variable)
+- [Test Method Documentation](#test-method-documentation)
+- [Comments in Tests](#comments-in-tests)
+- [Test Configuration](#test-configuration)
+- [Example: Schedule Time Calculator Tests](#example-schedule-time-calculator-tests)
+- [General Testing Best Practices](#general-testing-best-practices)
+
+## Complete Test File Template
+
+Use this template when creating new test files. It shows all conventions applied together:
+
+```php
+<?php
+declare( strict_types = 1 );
+
+namespace WPSP\Tests\Helpers;
+
+use WPSP\Helpers\TimeCalculator;
+use WP_UnitTestCase;
+
+/**
+ * Tests for the TimeCalculator class.
+ */
+class TimeCalculatorTest extends WP_UnitTestCase {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var TimeCalculator
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new TimeCalculator();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should return a future timestamp when given a valid offset.
+	 */
+	public function test_returns_future_timestamp_for_valid_offset(): void {
+		$result = $this->sut->calculate_publish_time( 3600 );
+
+		$this->assertGreaterThan( time(), $result, 'Calculated time should be in the future' );
+	}
+
+	/**
+	 * @testdox Should throw exception when offset is negative.
+	 */
+	public function test_throws_exception_for_negative_offset(): void {
+		$this->expectException( \InvalidArgumentException::class );
+
+		$this->sut->calculate_publish_time( -1 );
+	}
+}
+```
+
+### Key Elements
+
+| Element | Requirement |
+| ------- | ----------- |
+| `declare( strict_types = 1 )` | Required at file start |
+| Namespace | Match source location: `WPSP\Tests\{subdirectory}` |
+| Base class | Extend `WP_UnitTestCase` |
+| SUT variable | Use `$sut` with docblock "The System Under Test." |
+| Test docblock | Use `@testdox` with sentence ending in `.` |
+| Return type | Use `void` for test methods |
+| Assertion messages | Include helpful context for failures |
+
+## Test File Naming and Location
+
+| Source | Test | Pattern |
+| ------ | ---- | ------- |
+| `includes/Helpers/TimeCalculator.php` | `tests/unit/Helpers/TimeCalculatorTest.php` | Append `Test` (no hyphen) |
+| `includes/API/ScheduleRoute.php` | `tests/unit/API/ScheduleRouteTest.php` | Append `Test` |
+| `includes/Social/Twitter.php` | `tests/unit/Social/TwitterTest.php` | Append `Test` |
+
+- Unit tests live in `tests/unit/` mirroring the `includes/` subdirectory structure.
+- Integration tests live in `tests/integration/`.
+- Test class name = source class name + `Test` suffix, extends `WP_UnitTestCase`.
+
+## System Under Test Variable
+
+Use `$sut` with docblock "The System Under Test."
+
+```php
+/**
+ * The System Under Test.
+ *
+ * @var TimeCalculator
+ */
+private $sut;
+```
+
+## Test Method Documentation
+
+When adding or modifying a unit test method, the part of the docblock that describes the test must be prepended with `@testdox`. End the comment with `.` for compliance with linting rules.
+
+**Example:**
+
+```php
+/**
+ * @testdox Should return true when post is scheduled.
+ */
+public function test_returns_true_for_scheduled_post() {
+    // ...
+}
+
+/**
+ * @testdox Should throw exception when post ID is invalid.
+ */
+public function test_throws_exception_for_invalid_post_id() {
+    // ...
+}
+```
+
+## Comments in Tests
+
+**Avoid over-commenting tests.** Test names and assertion messages should explain intent.
+
+**Good - Self-explanatory:**
+
+```php
+/**
+ * @testdox Should return true when post status is future.
+ */
+public function test_returns_true_for_future_posts() {
+    $post_id = $this->factory->post->create( array( 'post_status' => 'future' ) );
+
+    $result = $this->sut->is_scheduled( $post_id );
+
+    $this->assertTrue( $result, 'Future posts should be considered scheduled' );
+}
+```
+
+**Avoid - Over-commented:**
+
+```php
+/**
+ * @testdox Should return true when post status is future.
+ */
+public function test_returns_true_for_future_posts() {
+    // Create a future post
+    $post_id = $this->factory->post->create( array( 'post_status' => 'future' ) );
+
+    // Call the method we're testing
+    $result = $this->sut->is_scheduled( $post_id );
+
+    // Verify the result is true
+    $this->assertTrue( $result, 'Future posts should be considered scheduled' );
+}
+```
+
+**Avoid - Arrange/Act/Assert comments:**
+
+```php
+// Don't add these structural comments
+// Arrange
+$post_id = $this->factory->post->create( array( 'post_status' => 'future' ) );
+
+// Act
+$result = $this->sut->is_scheduled( $post_id );
+
+// Assert
+$this->assertTrue( $result );
+```
+
+Use blank lines for visual separation instead. The test structure should be self-evident.
+
+**When comments ARE useful in tests:**
+
+- Explaining complex test setup: `// Simulate concurrent schedule update`
+- Documenting known issues: `// Workaround for WordPress core timezone bug`
+- Clarifying business rules: `// Auto-scheduler requires 15 min minimum gap`
+
+## Test Configuration
+
+Test configuration file: `phpunit.xml`
+
+Test suites:
+- `unit` — runs `tests/unit/**/*Test.php`
+- `integration` — runs `tests/integration/**/*Test.php`
+
+Run unit tests only:
+```bash
+vendor/bin/phpunit --testsuite unit
+```
+
+Run a single test class:
+```bash
+vendor/bin/phpunit --filter TimeCalculatorTest
+```
+
+## Example: Schedule Time Calculator Tests
+
+The following demonstrates good testing patterns for SchedulePress-specific functionality using data providers.
+
+### Key Patterns Used
+
+1. **Data-driven tests** using PHPUnit data providers
+2. **Post status verification** for different scheduling scenarios
+3. **Clear test organization** by feature area
+
+### Example Test Structure
+
+```php
+class AutoSchedulerTest extends WP_UnitTestCase {
+    /**
+     * The System Under Test.
+     *
+     * @var AutoScheduler
+     */
+    private $sut;
+
+    public function setUp(): void {
+        parent::setUp();
+        $this->sut = new AutoScheduler();
+    }
+
+    /**
+     * @testdox Should return correct next slot for various post types.
+     * @dataProvider post_type_slot_data
+     */
+    public function test_get_next_slot_for_post_type(
+        string $post_type,
+        string $expected_status
+    ) {
+        $post_id = $this->factory->post->create(
+            array(
+                'post_type'   => $post_type,
+                'post_status' => 'draft',
+            )
+        );
+
+        $result = $this->sut->get_next_available_slot( $post_id );
+
+        $this->assertSame(
+            $expected_status,
+            $result['status'],
+            "Expected status '{$expected_status}' for post type '{$post_type}'"
+        );
+    }
+
+    /**
+     * Data provider for post type slot tests.
+     *
+     * @return array
+     */
+    public function post_type_slot_data() {
+        return array(
+            'standard post' => array( 'post', 'available' ),
+            'page'          => array( 'page', 'available' ),
+            'custom type'   => array( 'product', 'unavailable' ),
+        );
+    }
+}
+```
+
+## General Testing Best Practices
+
+1. **Always run tests after making changes** to verify functionality
+2. **Write descriptive test names** that explain what is being tested
+3. **Use data providers** for testing multiple scenarios with the same logic
+4. **Include helpful assertion messages** for debugging when tests fail
+5. **Test both success and failure cases**
+6. **Use `$this->factory` helpers** for creating WordPress posts, users, terms, etc.
+7. **Clean up after tests** — `tearDown()` should undo any persistent state changes (options, post meta, etc.)

--- a/.claude/SKILLS.md
+++ b/.claude/SKILLS.md
@@ -1,0 +1,19 @@
+# Skills
+
+Project-specific skills for SchedulePress development.
+All skills live in [.ai/skills/](../.ai/skills/).
+
+---
+
+## Available Skills
+
+### [development](../.ai/skills/development/SKILL.md)
+Add or modify SchedulePress backend PHP code following project conventions.
+Invoke before writing any PHP classes, hooks, or unit tests.
+
+**Covers:**
+- [file-entities.md](../.ai/skills/development/file-entities.md) — class locations, PSR-4, namespace map
+- [code-entities.md](../.ai/skills/development/code-entities.md) — naming, visibility, static rules, docblocks
+- [coding-conventions.md](../.ai/skills/development/coding-conventions.md) — WordPress standards, null coalescing, ternary, linting
+- [hooks.md](../.ai/skills/development/hooks.md) — hook naming, callbacks, docblocks
+- [unit-tests.md](../.ai/skills/development/unit-tests.md) — `$sut`, `@testdox`, file location, test template

--- a/.distignore
+++ b/.distignore
@@ -70,3 +70,6 @@ vendor/priyomukul/.gitignore
 vendor/priyomukul/composer.json
 vendor/priyomukul/README.md
 docs/
+.ai
+AGENTS.md
+CLAUDE.md

--- a/.gitattributes
+++ b/.gitattributes
@@ -66,3 +66,6 @@ vendor/priyomukul/.editorconfig     export-ignore
 vendor/priyomukul/.gitignore       export-ignore
 vendor/priyomukul/composer.json     export-ignore
 vendor/priyomukul/README.md     export-ignore
+.ai                             export-ignore
+AGENTS.md                       export-ignore
+CLAUDE.md                       export-ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,262 @@
+# AGENTS.md — SchedulePress (wp-scheduled-posts)
+
+Rules and context for **all AI agents** working in this repository.
+Applies to: Claude Code, GitHub Copilot, Cursor, Codex, Gemini, Windsurf, Cline, and any other AI tool.
+
+---
+
+## Execution Sequence
+
+Always reply with **"Applying rules X, Y, Z"** when starting a task, listing which rules apply.
+
+1. **Search first** — use search tools until finding similar functionality or confirming none exists. Be 100% sure before implementing.
+2. **Reuse first** — check existing functions, patterns, and structure. Extend before creating new. Strive for the smallest possible change.
+3. **No assumptions** — only act on: files you have read, user messages, and tool results. If information is missing, search then ask.
+4. **Challenge ideas** — if you see flaws, risks, or better approaches, say so directly.
+5. **Be honest** — state what is needed or problematic. Do not sugarcoat to please.
+6. **Self-check** — periodically verify rule compliance during long conversations.
+7. **Rule refresh** — re-read this file every few messages to stay compliant.
+
+---
+
+## Behavior Rules
+
+### Must always do
+- Read a file before editing it. Never assume its contents.
+- Only change what was explicitly asked. No scope creep.
+- Plan before coding — explain reasoning for complex suggestions.
+- Verify that any file path, function, or constant you reference actually exists in the codebase before stating it.
+- Ask the user when a task is ambiguous or could have unintended side effects.
+- Run the relevant checks (see **Before Every Task**) before and after making changes.
+
+### Must never do
+- Write documentation unless explicitly asked.
+- Start dev servers — assume they are already running.
+- Modify legacy code without understanding the impact first.
+- Break existing API contracts without explicit approval.
+- Edit compiled output files — build from source instead.
+- Edit `vendor/`, `node_modules/`, or `includes/Deps/` — these are auto-generated.
+- Add comments, docblocks, or type annotations to code you did not write or modify.
+- Add error handling, abstractions, or features for hypothetical future requirements.
+- Refactor, reformat, or clean up code beyond what the task requires.
+- Commit `.env` files, API keys, OAuth tokens, or any credentials.
+- Use `--force`, `--no-verify`, or bypass any git hook or CI check.
+- Push to the remote unless the user explicitly asks.
+- Run destructive git commands (`reset --hard`, `clean -f`, `branch -D`) without user confirmation.
+
+---
+
+## Before Every Task
+
+Before making changes, confirm the baseline is clean:
+
+```bash
+# PHP changes
+./vendor/bin/phpcs          # check code standards
+./vendor/bin/phpunit        # run tests
+
+# JS / TS changes
+npm run build               # confirm build passes
+
+# Settings UI changes
+npm run admin-start         # dev server — verify in browser
+```
+
+Run the same commands **after** your changes to confirm nothing regressed.
+
+---
+
+## Code Conventions
+
+### PHP
+- Indentation: **tabs** (WordPress standard — not spaces)
+- Conditions: **Yoda style** — `if ( 'value' === $var )`
+- All custom functions, filters, and actions must be prefixed with `wpsp_`
+- Namespace all new classes under `WPSP\` (PSR-4, Composer-autoloaded)
+- No raw SQL — use `$wpdb->prepare()` or the WP Options/Post Meta API
+- All user-facing strings must be wrapped:
+  ```php
+  __( 'String', 'wp-scheduled-posts' )
+  _e( 'String', 'wp-scheduled-posts' )
+  ```
+
+### JavaScript / TypeScript
+- Functional React components only — no class components
+- Use `@wordpress/data` for shared state — no external state libraries
+- WordPress globals (`wp.*`, `jQuery`, `React`, `ReactDOM`) are injected by WordPress — never bundle them
+- Build preset: `@wordpress/babel-preset-default` (already configured)
+
+### CSS / SASS
+- Write styles in `assets/sass/` — never write directly to `assets/css/`
+- `assets/css/` is compiled output — edit the SASS source and rebuild
+- Do not introduce new CSS frameworks without discussion
+
+### General
+- Keep imports alphabetically sorted
+- Keep code SOLID but simple — separation of concerns without over-engineering
+- Write tests for critical paths only, using the AAA pattern (Arrange, Act, Assert)
+
+---
+
+## Code Style & Quality
+
+### Avoid Magic Numbers
+- Do not use unexplained hardcoded values ("magic numbers") in code or tests.
+- Define such values as named constants or use existing constants to clarify their meaning.
+
+### Consistent Error Codes and Status
+- When returning error codes and HTTP status, always be very specific — not only `200` and `500`.
+
+### Prioritize Style and Developer Experience
+- Always pay attention to clarity, maintainability, and ease of understanding, even if the underlying logic does not change.
+- Code style and developer experience are important for long-term project health.
+
+### Self-Documented Code
+- Avoid adding comments that can be a constant or a well-named function.
+- Always prefer to create small functions that describe themselves.
+- Only add comments to explain "why" when it is truly not understandable from the code itself.
+- Do NOT add comments that explain "what" the code does — the code should be self-explanatory.
+- Examples of unnecessary comments to avoid:
+  - `// Loop through items` (obvious from for loop)
+  - `// Check if user exists` (obvious from if statement)
+  - `// Return the result` (obvious from return statement)
+  - JSDoc comments that just repeat the function name or parameter names
+- Examples of valuable comments to keep:
+  - Business logic explanations that aren't obvious from code
+  - Workarounds for bugs in third-party libraries
+  - Performance optimizations that might look odd without context
+  - Complex algorithms where the "why" matters more than the "what"
+
+---
+
+## Security
+
+Every change that touches user input or output must follow these rules:
+
+| Situation | Required function |
+|-----------|------------------|
+| Sanitize text input | `sanitize_text_field()` |
+| Sanitize integer input | `absint()` |
+| Sanitize HTML content | `wp_kses_post()` |
+| Escape HTML output | `esc_html()` |
+| Escape attribute output | `esc_attr()` |
+| Escape URL output | `esc_url()` |
+| Database queries with input | `$wpdb->prepare()` |
+| Form submissions / AJAX | Verify nonce with `check_ajax_referer()` or `wp_verify_nonce()` |
+| Privileged actions | Check `current_user_can()` |
+
+Never trust client-supplied data for file paths, eval-style operations, or direct DB queries.
+
+---
+
+## Git & Commits
+
+- Never commit directly to `main` or `master` — use a feature branch
+- Stage files by name explicitly — never `git add .` or `git add -A`
+- Never amend a published commit — create a new commit instead
+- Commit messages: concise, describe *why* not just *what*
+- Never skip hooks (`--no-verify`)
+- Never push without the user asking
+
+---
+
+## Off-limits Files
+
+These files must **never** be manually edited:
+
+| Path | Reason |
+|------|--------|
+| `vendor/` | Composer-managed — use `composer install` |
+| `node_modules/` | npm-managed — use `npm install` |
+| `includes/Deps/` | Mozart-generated vendor namespace bundles |
+| `assets/js/*.min.js` | Webpack compiled output |
+| `assets/css/` | SASS compiled output |
+| `languages/*.mo` | Compiled translation binaries |
+
+---
+
+## Project Reference
+
+### Identity
+| Key | Value |
+|-----|-------|
+| Plugin name | SchedulePress |
+| Version | 5.2.17 |
+| Main file | `wp-scheduled-posts.php` |
+| PHP namespace | `WPSP\` |
+| Text domain | `wp-scheduled-posts` |
+| REST API base | `/wp-json/wp-scheduled-posts/v1/` |
+| Author | WPDeveloper |
+
+### Key Entry Points
+
+| What | File |
+|------|------|
+| Plugin bootstrap & main class | `wp-scheduled-posts.php` |
+| Admin UI controller | `includes/Admin.php` |
+| Settings (PHP) | `includes/Admin/Settings.php` |
+| Settings (React/TSX) | `includes/Admin/Settings/app/Settings/` |
+| Social sharing dispatcher | `includes/Social.php` |
+| Platform integrations | `includes/Social/*.php` |
+| REST API | `includes/API.php`, `includes/API/` |
+| Gutenberg sidebar | `index.js` |
+| Email notifications | `includes/Email.php` |
+| Helpers | `includes/Helper.php`, `includes/Helpers/` |
+
+### Build Commands
+
+| Command | What it does |
+|---------|-------------|
+| `npm run build` | Production build |
+| `npm start` | Dev watch (Gutenberg sidebar) |
+| `npm run admin-start` | Dev watch (Settings React UI) |
+| `npm run pot` | Generate `.pot` translation file |
+| `npm run release` | build + pot + ZIP archive |
+| `composer install` | Install PHP dependencies |
+
+### Test & Lint Commands
+
+```bash
+./vendor/bin/phpunit                         # all tests
+./vendor/bin/phpunit --testsuite unit        # unit tests only
+./vendor/bin/phpunit --testsuite integration # integration tests only
+./vendor/bin/phpcs                           # PHP code standards check
+./vendor/bin/phpcbf                          # auto-fix PHP standards
+```
+
+### PHP Architecture
+- **Pattern:** Singleton `WPSP` class with service-locator getters
+- **Boot:** `WPSP_Start()` → `new WPSP()` → `init_plugin()` on WordPress `init` hook
+- **Services:** `getAdmin()` · `getAssets()` · `getEmail()` · `getSocial()` · `getAPI()`
+- **Vendor isolation:** Mozart bundles all third-party namespaces under `WPSP\Deps\`
+
+### Runtime Constants
+
+| Constant | Purpose |
+|----------|---------|
+| `WPSP_VERSION` | Plugin version string |
+| `WPSP_ROOT` | Absolute path to plugin root |
+| `WPSP_URL` | URL to plugin root |
+| `WPSP_ASSETS` | URL to `assets/` directory |
+| `WPSP_TESTING` | `true` during PHPUnit test runs |
+
+### Common Task Guides
+
+**Add a social platform**
+1. Create `includes/Social/PlatformName.php` (mirror an existing platform)
+2. Register it in `includes/Social.php`
+3. Add settings fields in `includes/Admin/Settings.php`
+4. Add OAuth flow if needed
+
+**Modify the settings page**
+- PHP: `includes/Admin/Settings.php` (large — search for the right section)
+- React: `includes/Admin/Settings/app/Settings/`
+- Dev server: `npm run admin-start`
+
+**Add a REST endpoint**
+- Register via `register_rest_route()` in `includes/API.php` or a new file under `includes/API/`
+- Namespace: `wp-scheduled-posts/v1`
+
+**Release**
+1. Bump version in `wp-scheduled-posts.php`, `package.json`, `readme.txt`
+2. `npm run release` → produces `wp-scheduled-posts.{version}.zip`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,8 @@
 # CLAUDE.md — SchedulePress
 
 > All project rules, conventions, architecture, and task guides live in [AGENTS.md](./AGENTS.md).
-> Read that file first. This file only contains Claude Code-specific configuration.
+> Available skills are listed in [.claude/SKILLS.md](./.claude/SKILLS.md).
+> Read both files before starting any task.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# CLAUDE.md — SchedulePress
+
+> All project rules, conventions, architecture, and task guides live in [AGENTS.md](./AGENTS.md).
+> Read that file first. This file only contains Claude Code-specific configuration.
+
+---
+
+## Response Style
+
+- Be concise. No padding, no summaries of what you just did.
+- Do not use emojis unless asked.
+- Reference code locations as `file:line` so they are clickable.
+- When something is uncertain, say so — do not guess silently.
+
+## Tool Preferences
+
+- Use dedicated tools (Read, Edit, Grep, Glob, Write) over Bash equivalents.
+- Reserve Bash for commands that have no dedicated tool (running tests, builds, git).
+- When searching the codebase, use Grep or Glob before spawning an agent.
+- Prefer editing existing files over creating new ones.
+
+## Allowed Bash Commands
+
+These are pre-approved for this project and can be run without extra confirmation:
+
+```bash
+# Dependency install
+composer install
+npm install
+cd includes/Admin/Settings && npm install
+
+# Build
+npm run build
+npm run admin-start
+npm start
+
+# Tests & linting
+./vendor/bin/phpunit
+./vendor/bin/phpunit --testsuite unit
+./vendor/bin/phpunit --testsuite integration
+./vendor/bin/phpcs
+./vendor/bin/phpcbf
+
+# Git read-only
+git status
+git log
+git diff
+git branch
+```
+
+## Confirmation Required
+
+Always ask before:
+- Running `npm run release` or `npm run zip` (produces a distributable)
+- Any `git commit`, `git push`, `git merge`, or `git rebase`
+- Any destructive operation (`rm`, `git reset`, `git clean`)
+- Creating new files (prefer editing existing ones)
+
+## Memory
+
+If you learn something non-obvious about how this project works, the team's preferences,
+or decisions made during a session that would be useful in future sessions, save it to
+`/Users/shakib/.claude/projects/-Users-shakib-Documents-wordpress-schedulepress/memory/`.


### PR DESCRIPTION
Introduce repository AI guidance and SchedulePress PHP development skill docs. Adds .ai/skills/php-development (SKILL.md, code-entities.md, coding-conventions.md, file-entities.md, hooks.md, unit-tests.md) with conventions for backend code, hooks, and unit tests. Adds AGENTS.md (global AI agent rules) and CLAUDE.md (Claude-specific config). Update .distignore and .gitattributes to ignore and export-ignore the .ai directory and adjust vendor README export settings.