### PR TITLE
Fix: restore LinkedIn sharing broken by sunset API version 202507

### DIFF
--- a/includes/Social.php
+++ b/includes/Social.php
@@ -48,6 +48,10 @@ class Social
         $this->define('WPSCP_TWITTER_OPTION_NAME', 'twitter_profile_list');
         $this->define('WPSCP_GOOGLE_BUSINESS_OPTION_NAME', 'google_business_profile_list');
         // linkedin
+        // Legacy scopes. Kept because the bundled SchedulePress LinkedIn app does not
+        // have the "Sign In with LinkedIn using OpenID Connect" product enabled --
+        // requesting `openid` on it fails with unauthorized_scope_error. The OpenID
+        // scope constants below are for custom apps that do have that product.
         $this->define('WPSCP_LINKEDIN_SCOPE', 'r_emailaddress r_liteprofile w_member_social');
         $this->define('WPSCP_LINKEDIN_SCOPE_OPENID', 'openid profile email w_member_social');
         $this->define('WPSCP_LINKEDIN_SCOPE_OPENID_PAGE', 'openid profile email w_member_social r_organization_admin w_organization_social rw_organization_admin');

--- a/includes/Social/Linkedin.php
+++ b/includes/Social/Linkedin.php
@@ -183,7 +183,10 @@ class Linkedin
             $templates = get_post_meta($post_id, '_wpsp_custom_templates', true);
             $platform_data = isset($templates['linkedin']) ? $templates['linkedin'] : null;
             $profiles = is_array($platform_data) && isset($platform_data['profiles']) ? $platform_data['profiles'] : [];
-            if ( is_array($profiles) && !in_array($this->current_profile_id, $profiles) ) {
+            // An empty list means the custom template was enabled without picking any
+            // LinkedIn profile -- that is "no restriction", not "share to nobody".
+            // Without the !empty() check every share was dropped before any API call.
+            if ( is_array($profiles) && !empty($profiles) && !in_array($this->current_profile_id, $profiles) ) {
                 return;
             }
         }
@@ -286,6 +289,25 @@ class Linkedin
                 } else if (isset($result->code, $result->message) && $result->code === 'INVALID_STRING_FORMAT') {
                     $errorFlag = false;
                     $response = $result->message;
+                } else {
+                    // Catch-all: LinkedIn returns plenty of error shapes that carry
+                    // neither an id nor a serviceErrorCode (e.g. 426 NONEXISTENT_VERSION).
+                    // Without this the log stayed empty and the failure looked silent.
+                    $errorFlag = false;
+                    if (!empty($result) && is_object($result) && isset($result->message)) {
+                        $response = $result->message;
+                        if (isset($result->code) && $result->code === 'NONEXISTENT_VERSION') {
+                            $response = sprintf(
+                                /* translators: %s: LinkedIn API version */
+                                __('LinkedIn rejected API version %s (no longer supported). Please update SchedulePress.', 'wp-scheduled-posts'),
+                                $linkedin->apiVersion()
+                            );
+                        }
+                    } elseif (is_string($results) && $results !== '') {
+                        $response = $results;
+                    } else {
+                        $response = __('LinkedIn returned an unexpected response. Please try again.', 'wp-scheduled-posts');
+                    }
                 }
             } catch (\Exception $e) {
                 $errorFlag = false;
@@ -365,6 +387,11 @@ class Linkedin
         $response = $this->remote_post($post_id, $profile_key, true);
         if( $is_share_on_publish ) {
             return;
+        }
+        // remote_post() bails out with a bare `return;` on several skip conditions.
+        // Without this the array access below warns and the UI shows a blank error.
+        if ( !is_array($response) ) {
+            wp_send_json_error(__('Sharing was skipped for this profile. Check the post\'s social share settings.', 'wp-scheduled-posts'));
         }
         if ($response['success'] == false) {
             wp_send_json_error($response['log']);

--- a/vendor/wpdevelopers/linkedin-sdk-php/LinkedIn.php
+++ b/vendor/wpdevelopers/linkedin-sdk-php/LinkedIn.php
@@ -4,6 +4,8 @@ namespace myPHPNotes;
 
 
 class LinkedIn {
+    const DEFAULT_API_VERSION = '202607';
+
     protected $app_id;
     protected $app_secret;
     protected $callback;
@@ -18,6 +20,26 @@ class LinkedIn {
         $this->callback = $callback;
         $this->ssl = $ssl;
     }
+    /**
+     * Resolve the LinkedIn API version sent in the LinkedIn-Version header.
+     *
+     * LinkedIn versions are supported for one year from release, so a
+     * hardcoded value silently sunsets and every /rest/* call starts
+     * returning 426 NONEXISTENT_VERSION. Keep this overridable so a site
+     * can be unblocked without shipping a plugin release.
+     */
+    public function apiVersion() {
+        $version = defined('WPSCP_LINKEDIN_API_VERSION') ? WPSCP_LINKEDIN_API_VERSION : self::DEFAULT_API_VERSION;
+        if (function_exists('apply_filters')) {
+            $version = apply_filters('wpsp_linkedin_api_version', $version);
+        }
+        return preg_match('/^\d{6}$/', (string) $version) ? (string) $version : self::DEFAULT_API_VERSION;
+    }
+
+    protected function versionHeader() {
+        return 'LinkedIn-Version: ' . $this->apiVersion();
+    }
+
     public function getAuthUrl() {
         $_SESSION['linkedincsrf']  = $this->csrf;
         return "https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=" . $this->app_id . "&redirect_uri=" . $this->callback . "&state=" . $this->csrf . "&scope=" . $this->scopes;
@@ -76,7 +98,7 @@ class LinkedIn {
         $header = [
             "Authorization: Bearer {$accessToken}",
             'X-Restli-Protocol-Version: 2.0.0',
-            'LinkedIn-Version: 202507',
+            $this->versionHeader(),
         ];
 
         $company_pages = "https://api.linkedin.com/v2/organizationalEntityAcls?q=roleAssignee&role=ADMINISTRATOR&state=APPROVED&projection=(elements*(organizationalTarget~(id,localizedName,logoV2(original~:playableStreams))))";
@@ -105,7 +127,7 @@ class LinkedIn {
         $header = [
             "Authorization: Bearer {$accessToken}",
             'X-Restli-Protocol-Version: 2.0.0',
-            'LinkedIn-Version: 202507',
+            $this->versionHeader(),
         ];
         $request = [
             // "author": "urn:li:organization:5515715",
@@ -157,7 +179,7 @@ class LinkedIn {
         ]);
         $headers = [
             "Authorization: Bearer {$access_token}",
-            'LinkedIn-Version: 202507',
+            $this->versionHeader(),
             "X-RestLi-Protocol-Version: 2.0.0"
         ];
 
@@ -171,7 +193,7 @@ class LinkedIn {
             $content_type = "image/jpeg";
             $headers = [
                 "Authorization: Bearer {$access_token}",
-                'LinkedIn-Version: 202507',
+                $this->versionHeader(),
                 "X-RestLi-Protocol-Version: 2.0.0",
                 "Content-Length: " . strlen($parameters),
             ];
@@ -216,7 +238,7 @@ class LinkedIn {
         $content_type = "application/json";
         $headers = [
             "Authorization: Bearer {$access_token}",
-            'LinkedIn-Version: 202507',
+            $this->versionHeader(),
             "X-RestLi-Protocol-Version: 2.0.0",
             "Content-Length: " . strlen($parameters),
         ];
@@ -257,7 +279,7 @@ class LinkedIn {
 
         $headers = [
             "Authorization: Bearer {$accessToken}",
-            'LinkedIn-Version: 202507',
+            $this->versionHeader(),
             "X-RestLi-Protocol-Version: 2.0.0",
             "Content-Length: " . strlen($parameters),
         ];

--- a/wp-scheduled-posts.php
+++ b/wp-scheduled-posts.php
@@ -112,7 +112,7 @@ final class WPSP
 		define('WPSP_ASSETS_URI', WPSP_PLUGIN_ROOT_URI . 'assets/');
 		define('WPSCP_ADMIN_DIR_PATH', WPSP_ROOT_DIR_PATH . '/includes/Admin/');
 		// Midleware
-		define('WPSP_SOCIAL_OAUTH2_TOKEN_MIDDLEWARE', 'https://api.schedulepress.com.test/callback.php');
+		define('WPSP_SOCIAL_OAUTH2_TOKEN_MIDDLEWARE', 'https://api.schedulepress.com/callback.php');
 		define('WPSP_SOCIAL_OAUTH2_TOKEN_MIDDLEWARE_DEV', 'https://devapi.schedulepress.com/v2/callback.php');
 		define('WPSP_SOCIAL_OAUTH2_PINTEREST_APP_ID', '1478596');
 		define('WPSP_SOCIAL_OAUTH2_LINKEDIN_APP_ID', '77nbfvpkganvt6');


### PR DESCRIPTION
## Problem

LinkedIn sharing fails for every SchedulePress install, free and pro, on all shipped versions. The share silently does nothing and the UI shows a blank or generic error.

## Root cause

Two independent bugs.

**1. Sunset API version (affects everyone)**

`vendor/wpdevelopers/linkedin-sdk-php/LinkedIn.php` hardcoded `LinkedIn-Version: 202507` in six places (lines 79, 108, 160, 174, 219, 260). LinkedIn supports each Marketing API version for a minimum of one year; 202507 (July 2025) was sunset in July 2026. Every `/rest/posts` and `/rest/images` call now returns `426 NONEXISTENT_VERSION`.

The failure looked silent because `includes/Social/Linkedin.php:275-289` only matched `id`, `serviceErrorCode`, and `code === 'INVALID_STRING_FORMAT'`. The 426 body carries `code` + `message` but no `serviceErrorCode`, so it fell through all three branches, `$response` stayed `''`, and the UI rendered an empty error.

**2. Empty custom-template profile list drops the share**

`includes/Social/Linkedin.php:186`:

```php
$profiles = ... $platform_data['profiles'] ... : [];
if ( is_array($profiles) && !in_array($this->current_profile_id, $profiles) ) {
    return;
}
```

When a post has `_wpsp_enable_custom_social_template` enabled but no LinkedIn profile selected, `$profiles` is `[]`, so `in_array()` can never match and `remote_post()` returns early — before any LinkedIn call. `socialMediaInstantShare()` then does `$response['success']` on `null`, warns, and `wp_send_json_error()` sends a non-string, so the admin JS falls back to its generic `"Failed to share."` literal.

## Fix

| File | Change |
| --- | --- |
| `vendor/wpdevelopers/linkedin-sdk-php/LinkedIn.php` | Added `DEFAULT_API_VERSION = '202607'` and `apiVersion()`, overridable via the `WPSCP_LINKEDIN_API_VERSION` constant or the `wpsp_linkedin_api_version` filter, validated against `/^\d{6}$/`. All six hardcoded headers now call `versionHeader()`. |
| `includes/Social/Linkedin.php:186` | Added `!empty($profiles)` — an empty list means "no restriction", not "share to nobody". |
| `includes/Social/Linkedin.php:292` | Catch-all error branch so any LinkedIn error shape surfaces a message; `NONEXISTENT_VERSION` gets a plain-language string naming the version. |
| `includes/Social/Linkedin.php:391` | `!is_array($response)` guard so skip conditions report a real message instead of warning on a null array access. |
| `wp-scheduled-posts.php:115` | `https://api.schedulepress.com.test/callback.php` to `https://api.schedulepress.com/callback.php`; the `.test` host does not resolve. |
| `includes/Social.php:51` | Comment only. Documents why the legacy scopes must stay (see below). |

The filter is the point of the first change: the next sunset is July 2027, and a site can be unblocked without waiting for a release.

## Verification

Verified against the live LinkedIn API with a real connected token, and end-to-end through the plugin UI on a WordPress site running 5.3.2.

| Check | Before | After |
| --- | --- | --- |
| `POST /rest/posts`, version 202507 | `426 NONEXISTENT_VERSION` — "Requested version 20250701 is not active" | n/a |
| `POST /rest/posts`, version 202607 | n/a | `201 Created` |
| `POST /rest/images?action=initializeUpload`, 202607 | n/a | `200 OK`, returns upload URL + image URN |
| Share Now, custom template on, no profile selected | `"Failed to share."`, no API call made | Post published to LinkedIn |
| Error message on a rejected share | blank | LinkedIn's actual message |
| Account connect (OAuth) | works | works, unchanged |

Regression checked: the OAuth connect flow still authorizes. The legacy scopes `r_emailaddress r_liteprofile w_member_social` were deliberately **left as-is** — the bundled SchedulePress LinkedIn app (`77nbfvpkganvt6`, app id 207101661) does not have the "Sign In with LinkedIn using OpenID Connect" product enabled, so requesting `openid` on it returns `unauthorized_scope_error` and breaks connect entirely. Confirmed by probing the authorize endpoint directly:

- `openid profile email w_member_social` → `Scope "openid" is not authorized for your application`
- `r_emailaddress r_liteprofile w_member_social` → `303` to LinkedIn login (accepted)

## Affected versions

All versions shipping `LinkedIn-Version: 202507`, including 5.3.2 (free) and Pro 5.3.1. Impact began when LinkedIn sunset the version in July 2026.

## Follow-ups (not in this PR)

- The same empty-`profiles` guard exists in all eight other platform classes — `Facebook.php:287`, `Twitter.php:177`, `Instagram.php:204`, `Pinterest.php:284`, `Threads.php:167`, `Medium.php:234`, `Bluesky.php:323`, `GoogleBusiness.php:102`. Same silent drop. Scoped out to keep this PR reviewable.
- Enabling the OpenID Connect product on the SchedulePress LinkedIn app in the developer portal would let the default scope move off the legacy `r_liteprofile`/`r_emailaddress`, which LinkedIn is retiring. That is an app-account change, not a code change.
- `DEFAULT_API_VERSION` still needs a yearly bump. The filter is the escape hatch, not the cure.
